### PR TITLE
feat: add property to skip publishing githb status

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,1 @@
-def configurations = [
-    [ platform: "linux", jdk: "8", jenkins: null ],
-    [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
-]
-buildPlugin(configurations: configurations, useAci: true)
+common{}

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -41,6 +41,12 @@ public abstract class GitHubChecksContext {
      */
     public abstract String getRepository();
 
+    /**
+     * Returns PR's author name in String.
+     * Return empty string if it is not PR or source not exist
+     *
+     * @return the author's name
+     */
     public String getContributor() {
         Optional<SCMHead> optionalHead = getScmFacade().findHead(getJob());
         if (optionalHead.isPresent()) {
@@ -50,10 +56,10 @@ public abstract class GitHubChecksContext {
                 String contributor = cm.getContributor();
                 return contributor;
             } else {
-                return "not PR";
+                return "";
             }
         }
-        return "source is null";
+        return "";
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -4,6 +4,9 @@ import edu.hm.hafner.util.FilteredLog;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.model.Job;
 import hudson.model.Run;
+import jenkins.scm.api.metadata.ContributorMetadataAction;
+import jenkins.scm.api.mixin.ChangeRequestSCMHead;
+import jenkins.scm.api.SCMHead;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 
@@ -37,6 +40,21 @@ public abstract class GitHubChecksContext {
      * @return the source repository's full name
      */
     public abstract String getRepository();
+
+    public String getContributor() {
+        Optional<SCMHead> optionalHead = getScmFacade().findHead(getJob());
+        if (optionalHead.isPresent()) {
+            SCMHead head = optionalHead.get();
+            if (head instanceof ChangeRequestSCMHead) {
+                ContributorMetadataAction cm = job.getAction(ContributorMetadataAction.class);
+                String contributor = cm.getContributor();
+                return contributor;
+            } else {
+                return "not PR";
+            }
+        }
+        return "source is null";
+    }
 
     /**
      * Returns whether the context is valid (with all properties functional) to use.

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksContext.java
@@ -55,7 +55,8 @@ public abstract class GitHubChecksContext {
                 ContributorMetadataAction cm = job.getAction(ContributorMetadataAction.class);
                 String contributor = cm.getContributor();
                 return contributor;
-            } else {
+            }
+            else {
                 return "";
             }
         }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -3,11 +3,14 @@ package io.jenkins.plugins.checks.github;
 import edu.hm.hafner.util.VisibleForTesting;
 import io.jenkins.plugins.checks.api.ChecksDetails;
 import io.jenkins.plugins.checks.api.ChecksPublisher;
+import io.jenkins.plugins.checks.github.status.GitHubStatusChecksProperties;
 import io.jenkins.plugins.util.PluginLogger;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.github_branch_source.Connector;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.kohsuke.github.GHCheckRun;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHCheckRunBuilder;
 import org.kohsuke.github.GitHub;
 
@@ -25,6 +28,7 @@ import static java.lang.String.format;
  */
 public class GitHubChecksPublisher extends ChecksPublisher {
     private static final String GITHUB_URL = "https://api.github.com";
+    private static final String CONFLUENTINC = "confluentinc";
     private static final Logger SYSTEM_LOGGER = Logger.getLogger(GitHubChecksPublisher.class.getName());
 
     private final GitHubChecksContext context;
@@ -61,30 +65,43 @@ public class GitHubChecksPublisher extends ChecksPublisher {
             GitHubAppCredentials credentials = context.getCredentials();
             GitHub gitHub = Connector.connect(StringUtils.defaultIfBlank(credentials.getApiUri(), gitHubUrl),
                     credentials);
+            String contributor = context.getContributor();
+            buildLogger.log("contributor name is " + contributor);
+            String repository = context.getRepository();
+            boolean isPrivate = gitHub.getRepository(repository).isPrivate();
+            GitHubStatusChecksProperties gitHubStatusChecksProperties = new GitHubStatusChecksProperties();
+            boolean publishNonConfluentIncPR = gitHubStatusChecksProperties.isPublishNonConfluentIncPR(context.getJob());
+            boolean publishConfluentIncPR = gitHubStatusChecksProperties.isPublishConfluentIncPR(context.getJob());
+            buildLogger.log("publishNonConfluentIncPR is " + publishNonConfluentIncPR);
+            buildLogger.log("publishConfluentIncPR is " + publishConfluentIncPR);
+            boolean isConfluentInc = orgCheck(contributor, gitHub, isPrivate);
+            boolean skipPublish = skipPublish(isPrivate, isConfluentInc, publishNonConfluentIncPR, publishConfluentIncPR);
+            buildLogger.log("skip publishing github status : " + skipPublish);
+            if (!skipPublish) {
+                GitHubChecksDetails gitHubDetails = new GitHubChecksDetails(details);
 
-            GitHubChecksDetails gitHubDetails = new GitHubChecksDetails(details);
+                Optional<Long> existingId = context.getId(gitHubDetails.getName());
 
-            Optional<Long> existingId = context.getId(gitHubDetails.getName());
+                final GHCheckRun run;
 
-            final GHCheckRun run;
+                if (existingId.isPresent()) {
+                    run = getUpdater(gitHub, gitHubDetails, existingId.get()).create();
+                }
+                else {
+                    run = getCreator(gitHub, gitHubDetails).create();
+                }
 
-            if (existingId.isPresent()) {
-                run = getUpdater(gitHub, gitHubDetails, existingId.get()).create();
+                context.addActionIfMissing(run.getId(), gitHubDetails.getName());
+
+                buildLogger.log("GitHub check (name: %s, status: %s) has been published.", gitHubDetails.getName(),
+                       gitHubDetails.getStatus());
+                SYSTEM_LOGGER.fine(format("Published check for repo: %s, sha: %s, job name: %s, name: %s, status: %s",
+                                context.getRepository(),
+                                context.getHeadSha(),
+                                context.getJob().getFullName(),
+                                gitHubDetails.getName(),
+                                gitHubDetails.getStatus()).replaceAll("[\r\n]", ""));
             }
-            else {
-                run = getCreator(gitHub, gitHubDetails).create();
-            }
-
-            context.addActionIfMissing(run.getId(), gitHubDetails.getName());
-
-            buildLogger.log("GitHub check (name: %s, status: %s) has been published.", gitHubDetails.getName(),
-                    gitHubDetails.getStatus());
-            SYSTEM_LOGGER.fine(format("Published check for repo: %s, sha: %s, job name: %s, name: %s, status: %s",
-                            context.getRepository(),
-                            context.getHeadSha(),
-                            context.getJob().getFullName(),
-                            gitHubDetails.getName(),
-                            gitHubDetails.getStatus()).replaceAll("[\r\n]", ""));
         }
         catch (IOException e) {
             String message = "Failed Publishing GitHub checks: ";
@@ -125,6 +142,62 @@ public class GitHubChecksPublisher extends ChecksPublisher {
         details.getActions().forEach(builder::add);
 
         return builder;
+    }
+
+    private boolean orgCheck(String username, GitHub github, boolean isPrivate) throws IOException {
+        // skip org check if the repo is private
+        if (isPrivate) {
+            return true;
+        }
+        try{
+            GHUser user = github.getUser(username);
+            GHOrganization org = github.getOrganization(CONFLUENTINC);
+            boolean isConfluentinc = user.isMemberOf(org);
+            buildLogger.log("contributorisConfluentinc: " + isConfluentinc);
+            return isConfluentinc;
+        } catch (IOException e) {
+            buildLogger.log("Failed to connect to GitHub " + e);
+            return false;
+        }
+    }
+
+    /**
+     * Whether to skip publishing github status.
+     *
+     * @param isPrivate
+     *         whether repo is private
+     * @param isConfluentInc
+     *         whether contributor is member of confluentinc
+     * @param publishNonConfluentIncPR
+     *         publish non-confluentinc PR status only
+     * @param publishConfluentIncPR
+     *         publish confluentinc PR status only
+     * @return true if skip publishing
+     */
+    private boolean skipPublish(boolean isPrivate,
+                         boolean isConfluentInc,
+                         boolean publishNonConfluentIncPR,
+                         boolean publishConfluentIncPR) {
+        if (isPrivate) {
+            // if repo is private, do not skip
+            return false;
+        } else if (!publishConfluentIncPR && !publishNonConfluentIncPR) {
+            return false;
+        } else {
+            // if contributor is member of confluentinc
+            if (isConfluentInc) {
+                if (publishConfluentIncPR)
+                    return false;
+                else if (publishNonConfluentIncPR)
+                    return true;
+            } else {
+                if (publishNonConfluentIncPR)
+                    return false;
+                else if (publishConfluentIncPR)
+                    return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -155,9 +155,9 @@ public class GitHubChecksPublisher extends ChecksPublisher {
         try {
             GHUser user = github.getUser(username);
             GHOrganization org = github.getOrganization(GITHUB_ORG);
-            boolean isConfluentinc = user.isMemberOf(org);
-            buildLogger.log("contributorisConfluentinc: " + isConfluentinc);
-            return isConfluentinc;
+            boolean inGithubOrg = user.isMemberOf(org);
+            buildLogger.log("inGithubOrg: " + inGithubOrg);
+            return inGithubOrg;
         }
         catch (IOException e) {
             buildLogger.log("Failed to connect to GitHub " + e);
@@ -183,7 +183,7 @@ public class GitHubChecksPublisher extends ChecksPublisher {
                          boolean publishNonConfluentIncPR,
                          boolean publishConfluentIncPR) {
         if (isPrivate) {
-            // if repo is private, do not skip
+            // if repo is private, we should publish
             return true;
         }
         else if (!publishConfluentIncPR && !publishNonConfluentIncPR) {

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -65,18 +65,23 @@ public class GitHubChecksPublisher extends ChecksPublisher {
             GitHubAppCredentials credentials = context.getCredentials();
             GitHub gitHub = Connector.connect(StringUtils.defaultIfBlank(credentials.getApiUri(), gitHubUrl),
                     credentials);
+            boolean skipPublish = false;
             String contributor = context.getContributor();
             buildLogger.log("contributor name is " + contributor);
-            String repository = context.getRepository();
-            boolean isPrivate = gitHub.getRepository(repository).isPrivate();
-            GitHubStatusChecksProperties gitHubStatusChecksProperties = new GitHubStatusChecksProperties();
-            boolean publishNonConfluentIncPR = gitHubStatusChecksProperties.isPublishNonConfluentIncPR(context.getJob());
-            boolean publishConfluentIncPR = gitHubStatusChecksProperties.isPublishConfluentIncPR(context.getJob());
-            buildLogger.log("publishNonConfluentIncPR is " + publishNonConfluentIncPR);
-            buildLogger.log("publishConfluentIncPR is " + publishConfluentIncPR);
-            boolean isConfluentInc = orgCheck(contributor, gitHub, isPrivate);
-            boolean skipPublish = skipPublish(isPrivate, isConfluentInc, publishNonConfluentIncPR, publishConfluentIncPR);
-            buildLogger.log("skip publishing github status : " + skipPublish);
+            if (contributor.isEmpty()) {
+                skipPublish = false;
+            } else {
+                String repository = context.getRepository();
+                boolean isPrivate = gitHub.getRepository(repository).isPrivate();
+                GitHubStatusChecksProperties gitHubStatusChecksProperties = new GitHubStatusChecksProperties();
+                boolean publishNonConfluentIncPR = gitHubStatusChecksProperties.isPublishNonConfluentIncPR(context.getJob());
+                boolean publishConfluentIncPR = gitHubStatusChecksProperties.isPublishConfluentIncPR(context.getJob());
+                buildLogger.log("publishNonConfluentIncPR is " + publishNonConfluentIncPR);
+                buildLogger.log("publishConfluentIncPR is " + publishConfluentIncPR);
+                boolean isConfluentInc = orgCheck(contributor, gitHub, isPrivate);
+                skipPublish = skipPublish(isPrivate, isConfluentInc, publishNonConfluentIncPR, publishConfluentIncPR);
+                buildLogger.log("skip publishing github status : " + skipPublish);
+            }
             if (!skipPublish) {
                 GitHubChecksDetails gitHubDetails = new GitHubChecksDetails(details);
 

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -178,7 +178,8 @@ public class GitHubChecksPublisher extends ChecksPublisher {
      *         publish confluentinc PR status only
      * @return true if we should publish github status
      */
-    private boolean shouldPublish(boolean isPrivate,
+    @VisibleForTesting
+    boolean shouldPublish(boolean isPrivate,
                          boolean inGithubOrg,
                          boolean publishNonConfluentIncPR,
                          boolean publishConfluentIncPR) {

--- a/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/GitHubChecksPublisher.java
@@ -187,28 +187,11 @@ public class GitHubChecksPublisher extends ChecksPublisher {
             return true;
         }
         else if (!publishConfluentIncPR && !publishNonConfluentIncPR) {
-            return false;
+            return true;
         }
         else {
-            // if contributor is member of confluentinc
-            if (inGithubOrg) {
-                if (publishConfluentIncPR) {
-                    return true;
-                }
-                else if (publishNonConfluentIncPR) {
-                    return false;
-                }
-            }
-            else {
-                if (publishNonConfluentIncPR) {
-                    return true;
-                }
-                else if (publishConfluentIncPR) {
-                    return false;
-                }
-            }
+            return (inGithubOrg && publishConfluentIncPR) || (!inGithubOrg && publishNonConfluentIncPR);
         }
-        return true;
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -26,6 +26,8 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     private String name = "Jenkins";
     private boolean suppressLogs = false;
     private boolean skipProgressUpdates = false;
+    private boolean publishConfluentIncPR = false;
+    private boolean PublishNonConfluentIncPR = false;
 
     /**
      * Constructor for stapler.
@@ -80,6 +82,14 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
         return skipProgressUpdates;
     }
 
+    public boolean isPublishConfluentIncPR() {
+        return publishConfluentIncPR;
+    }
+
+    public boolean isPublishNonConfluentIncPR() {
+        return PublishNonConfluentIncPR;
+    }
+
     @DataBoundSetter
     public void setSkipProgressUpdates(boolean skipProgressUpdates) {
         this.skipProgressUpdates = skipProgressUpdates;
@@ -120,6 +130,16 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     @DataBoundSetter
     public void setSuppressLogs(final boolean suppressLogs) {
         this.suppressLogs = suppressLogs;
+    }
+
+    @DataBoundSetter
+    public void setPublishConfluentIncPR(final boolean publishConfluentIncPR) {
+        this.publishConfluentIncPR = publishConfluentIncPR;
+    }
+
+    @DataBoundSetter
+    public void setPublishNonConfluentIncPR(final boolean publishNonConfluentIncPR) {
+        this.PublishNonConfluentIncPR = publishNonConfluentIncPR;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubSCMSourceStatusChecksTrait.java
@@ -27,7 +27,7 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     private boolean suppressLogs = false;
     private boolean skipProgressUpdates = false;
     private boolean publishConfluentIncPR = false;
-    private boolean PublishNonConfluentIncPR = false;
+    private boolean publishNonConfluentIncPR = false;
 
     /**
      * Constructor for stapler.
@@ -87,7 +87,7 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
     }
 
     public boolean isPublishNonConfluentIncPR() {
-        return PublishNonConfluentIncPR;
+        return publishNonConfluentIncPR;
     }
 
     @DataBoundSetter
@@ -139,7 +139,7 @@ public class GitHubSCMSourceStatusChecksTrait extends SCMSourceTrait implements 
 
     @DataBoundSetter
     public void setPublishNonConfluentIncPR(final boolean publishNonConfluentIncPR) {
-        this.PublishNonConfluentIncPR = publishNonConfluentIncPR;
+        this.publishNonConfluentIncPR = publishNonConfluentIncPR;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
@@ -40,8 +40,18 @@ public interface GitHubStatusChecksConfigurations {
      */
     boolean isSkipProgressUpdates();
     
+    /**
+     * Return whether to publish github status check for confluent PR only.
+     * 
+     * @return true if publish confluent PR only
+     */
     boolean isPublishConfluentIncPR();
 
+    /**
+     * Return whether to publish github status check for non-confluent PR only.
+     * 
+     * @return true if publish non-confluent PR only
+     */
     boolean isPublishNonConfluentIncPR();
 }
 

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksConfigurations.java
@@ -39,6 +39,10 @@ public interface GitHubStatusChecksConfigurations {
      * @return true if progress updates should be skipped.
      */
     boolean isSkipProgressUpdates();
+    
+    boolean isPublishConfluentIncPR();
+
+    boolean isPublishNonConfluentIncPR();
 }
 
 class DefaultGitHubStatusChecksConfigurations implements GitHubStatusChecksConfigurations {
@@ -64,6 +68,16 @@ class DefaultGitHubStatusChecksConfigurations implements GitHubStatusChecksConfi
 
     @Override
     public boolean isSkipProgressUpdates() {
+        return false;
+    }
+
+    @Override
+    public boolean isPublishConfluentIncPR() {
+        return false;
+    }
+
+    @Override
+    public boolean isPublishNonConfluentIncPR() {
         return false;
     }
 }

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -67,6 +67,14 @@ public class GitHubStatusChecksProperties extends AbstractStatusChecksProperties
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSkipProgressUpdates();
     }
 
+    public boolean isPublishConfluentIncPR(Job<?, ?> job) {
+        return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isPublishConfluentIncPR();
+    }
+
+    public boolean isPublishNonConfluentIncPR(Job<?, ?> job) {
+        return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isPublishNonConfluentIncPR();
+    }
+
     private Optional<GitHubStatusChecksConfigurations> getConfigurations(final Job<?, ?> job) {
         Optional<GitHubSCMSource> gitHubSCMSource = scmFacade.findGitHubSCMSource(job);
         if (gitHubSCMSource.isPresent()) {

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitHubStatusChecksProperties.java
@@ -67,10 +67,26 @@ public class GitHubStatusChecksProperties extends AbstractStatusChecksProperties
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isSkipProgressUpdates();
     }
 
+    /**
+     * Returns whether to publish confluentinc PR only.
+     *
+     * @param job
+     *         the job to get the configurations for
+     *
+     * @return true if publishing confluentinc PR only
+     */
     public boolean isPublishConfluentIncPR(Job<?, ?> job) {
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isPublishConfluentIncPR();
     }
 
+    /**
+     * Returns whether to publish non confluentinc PR only.
+     *
+     * @param job
+     *         the job to get the configurations for
+     *
+     * @return true if publishing non confluentinc PR only
+     */
     public boolean isPublishNonConfluentIncPR(Job<?, ?> job) {
         return getConfigurations(job).orElse(DEFAULT_CONFIGURATION).isPublishNonConfluentIncPR();
     }

--- a/src/main/java/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension.java
+++ b/src/main/java/io/jenkins/plugins/checks/github/status/GitSCMStatusChecksExtension.java
@@ -20,6 +20,8 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     private String name = "Jenkins";
     private boolean suppressLogs;
     private boolean skipProgressUpdates = false;
+    private boolean publishConfluentIncPR = false;
+    private boolean publishNonConfluentIncPR = false;
 
     /**
      * Constructor for stapler.
@@ -52,6 +54,16 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     @Override
     public boolean isSkipProgressUpdates() {
         return skipProgressUpdates;
+    }
+
+    @Override
+    public boolean isPublishConfluentIncPR() {
+        return publishConfluentIncPR;
+    }
+
+    @Override
+    public boolean isPublishNonConfluentIncPR() {
+        return publishNonConfluentIncPR;
     }
 
     @DataBoundSetter
@@ -89,6 +101,16 @@ public class GitSCMStatusChecksExtension extends GitSCMExtension implements GitH
     @DataBoundSetter
     public void setSuppressLogs(final boolean suppressLogs) {
         this.suppressLogs = suppressLogs;
+    }
+
+    @DataBoundSetter
+    public void setPublishConfluentIncPR(final boolean publishConfluentIncPR) {
+        this.publishConfluentIncPR = publishConfluentIncPR;
+    }
+
+    @DataBoundSetter
+    public void setPublishNonConfluentIncPR(final boolean publishNonConfluentIncPR) {
+        this.publishNonConfluentIncPR = publishNonConfluentIncPR;
     }
 
     /**

--- a/src/main/resources/lib/github-checks/status/properties.jelly
+++ b/src/main/resources/lib/github-checks/status/properties.jelly
@@ -22,4 +22,13 @@
     <f:checkbox/>
   </f:entry>
 
+  <f:entry title="${%Only Publish confluentinc PR status}" field="publishConfluentIncPR"
+           description="${%Publish github status for confluentinc PR only}">
+    <f:checkbox/>
+  </f:entry>
+
+  <f:entry title="${%Only Publish non confluentinc PR status}" field="publishNonConfluentIncPR"
+           description="${%Publish github status for non confluentinc PR only}">
+    <f:checkbox/>
+  </f:entry>
 </j:jelly>

--- a/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherTest.java
+++ b/src/test/java/io/jenkins/plugins/checks/github/GitHubChecksPublisherTest.java
@@ -1,0 +1,35 @@
+package io.jenkins.plugins.checks.github;
+
+import org.junit.jupiter.api.Test;
+
+import io.jenkins.plugins.util.PluginLogger;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GitHubChecksPublisherTest {
+    @Test
+    void shouldPublish() {
+        GitHubChecksContext gitHubChecksContext = mock(GitHubChecksContext.class);
+        PluginLogger logger = mock(PluginLogger.class);
+        GitHubChecksPublisher publisher = new GitHubChecksPublisher(gitHubChecksContext, logger);
+        // private repo
+        assertThat(publisher.shouldPublish(true, true, false, true)).isTrue();
+
+        // public repo with confluentinc member and publish non-confluent pr status
+        assertThat(publisher.shouldPublish(false, true, true, false)).isFalse();
+
+        // public repo with non-confluentinc member and publish confluent pr status
+        assertThat(publisher.shouldPublish(false, false, false, true)).isFalse();
+
+        // public repo with non-confluentinc member and publish non-confluent pr status
+        assertThat(publisher.shouldPublish(false, false, true, false)).isTrue();
+
+        // public repo with confluentinc member and publish confluent pr status
+        assertThat(publisher.shouldPublish(false, true, false, true)).isTrue();
+
+        // both properties are not set
+        assertThat(publisher.shouldPublish(false, false, false, false)).isTrue();
+
+    }
+}


### PR DESCRIPTION
## what
----------------
Add `publishConfluentIncPR` and `publishNonConfluentIncPR` to help control how we publish github status check.
- publishConfluentIncPR only publish github status check when the PR author is confluentinc member
- publishNonConfluentIncPR only publish github statys check when the PR author is not a confluentinc member

## how
------------------
- Add two new parameters 
- Add a `getContributor` method that return PR author
- Add an `orgCheck` method that check if the github user is part of confluentinc
- Add `skipPublish` to set whether it should skip publish github status

## test
--------------------
Install on https://jenkins.public.confluent.io/
https://jenkins.public.confluent.io/job/xli1996-common/view/change-requests/job/PR-6/
