### PR TITLE
Set appropriate code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jenkinsci/github-checks-plugin-developers
+*	@confluentinc/devprod


### PR DESCRIPTION
The current code owner isn't in the `confluentinc` organization. This changes the owner to be `@confluentinc/devprod`. 